### PR TITLE
Fix a small typo in changelog dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ For example, the following attributes all work:
 
 ### validator
 
-#### 0.6.0 (2017/09/12)
+#### 0.6.0 (2017/08/12)
 
 - Re-design `ValidationError` and `Validate` trait
 
 ### validator_derive
 
-#### 0.6.0 (2017/09/12)
+#### 0.6.0 (2017/08/12)
 
 - Change generated code to make the new design of errors work
 


### PR DESCRIPTION
Since 0.6.0 is already on crates.io I suppose it was supposed to be this month
and not last month.

Love the library by the way :)